### PR TITLE
Made it possible to suppress categories in favour of tags in the index.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -27,9 +27,16 @@
                         <header class="post-header">
                             <h3><a class="post-title" href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></h3>
                             <p class="post-meta">{{ article.summary }}</p>
+                        {% if HIDE_CATEGORIES %}
+                            <p class="post-meta">// under {% for tag in article.tags %}
+                                <a class="post-category" href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>
+                                {% endfor %} &middot; {{ article.locale_date }}
+                            </p>
+                        {% else %}
                             <p class="post-meta">
                                 in <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a> &middot; {{ article.locale_date }}
                             </p>
+                        {% endif %}
                         </header>
                     </section>
                 {% endfor %}


### PR DESCRIPTION
For blogs that don't use categories, this makes it possible to hide the ``in SomeCategory`` line on posts in the index in favour of a ``// under [tag list]`` line. To enable this, the user must specify 

```python
HIDE_CATEGORIES = True
```

in their configuration file.