### PR TITLE
Remove SITEURL prefix from MENUITEMS links

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -48,7 +48,7 @@
                             <h1 class="brand-main"><a href="{{ SITEURL }}">{{ SITENAME }}</a></h1>
                             <p class="tagline">{{ TAGLINE }}</p>
                             {% for title, link in MENUITEMS %}
-                                <p class="links"><a href="{{ SITEURL }}/{{ link }}">{{ title }}</a></p>
+                                <p class="links"><a href="{{ link }}">{{ title }}</a></p>
                             {% endfor %}
                                 <p class="social">
                             {% for title, link in SOCIAL %}


### PR DESCRIPTION
MENUITEMS links could be external links for authors. This thus should
not be automatically prefixed by the SITEURL.